### PR TITLE
Add filter for available $languages

### DIFF
--- a/includes/class-fw-language.php
+++ b/includes/class-fw-language.php
@@ -62,7 +62,7 @@ class FW_Language {
 		'jv'  => array( 'locale' => 'jv_ID', 'name' => 'Basa Jawa', 'direction' => '', ),
 		'ka'  => array( 'locale' => 'ka_GE', 'name' => 'ქართული', 'direction' => '', ),
 		'kk'  => array( 'locale' => 'kk', 'name' => 'Қазақ тілі', 'direction' => '', ),
-		'ko'  => array( 'locale' => 'ko_KR', 'name' => '한국어', e'direction' => '', ),
+		'ko'  => array( 'locale' => 'ko_KR', 'name' => '한국어', 'direction' => '', ),
 		'ku'  => array( 'locale' => 'ckb', 'name' => 'کوردی', 'direction' => 'rtl', ),
 		'lo'  => array( 'locale' => 'lo', 'name' => 'ພາສາລາວ', 'direction' => '', ),
 		'lt'  => array( 'locale' => 'lt_LT', 'name' => 'Lietuviškai', 'direction' => '', ),

--- a/includes/class-fw-language.php
+++ b/includes/class-fw-language.php
@@ -62,7 +62,7 @@ class FW_Language {
 		'jv'  => array( 'locale' => 'jv_ID', 'name' => 'Basa Jawa', 'direction' => '', ),
 		'ka'  => array( 'locale' => 'ka_GE', 'name' => 'ქართული', 'direction' => '', ),
 		'kk'  => array( 'locale' => 'kk', 'name' => 'Қазақ тілі', 'direction' => '', ),
-		'ko'  => array( 'locale' => 'ko_KR', 'name' => '한국어', 'direction' => '', ),
+		'ko'  => array( 'locale' => 'ko_KR', 'name' => '한국어', e'direction' => '', ),
 		'ku'  => array( 'locale' => 'ckb', 'name' => 'کوردی', 'direction' => 'rtl', ),
 		'lo'  => array( 'locale' => 'lo', 'name' => 'ພາສາລາວ', 'direction' => '', ),
 		'lt'  => array( 'locale' => 'lt_LT', 'name' => 'Lietuviškai', 'direction' => '', ),
@@ -100,9 +100,10 @@ class FW_Language {
 	);
 
 	/**
-	 * Set $languages array.
+	 * Set $languages array, filtered to allow changes, for example to change the locale flag of a language.
 	 */
 	function __construct() {
+		$this->languages = apply_filters('fw_ext_translation_languages', $this->languages);
 		$this->codes = array_keys( $this->languages );
 	}
 


### PR DESCRIPTION
Lets developers change the available languages, locales and flags, so we can do:

```
// functions.php
add_filter( 'fw_ext_translation_languages', function( $langs ) {  
    // make changes...
    $langs['es']['locale'] = "es_ES";
    $langs['en']['locale'] = "en_GB";
    return $langs; } );
```
